### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/compile-mermaid.yml
+++ b/.github/workflows/compile-mermaid.yml
@@ -36,7 +36,7 @@ jobs:
         path: ./test
 
     - name: Publish to Github Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.17
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{env.GITHUB_REPOSITORY_LOWER_CASE}}/${{env.IMAGENAME}}
         username: $GITHUB_ACTOR
@@ -47,7 +47,7 @@ jobs:
         tags: "latest,${{env.RELEASE_VERSION}}"
 
     - name: Publish to Docker.io Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.17
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{env.DOCKER_IO_REPOSITORY}}
         username: ${{secrets.DOCKER_USERNAME}}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore